### PR TITLE
Add state management library "nanostores" for metadata of pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "hast-util-truncate": "^2.0.0",
     "katex": "^0.16.18",
     "mdast-util-to-string": "^4.0.0",
+    "nanostores": "^0.11.3",
     "pagefind": "^1.3.0",
     "reading-time": "^1.5.0",
     "rehype-external-links": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
+      nanostores:
+        specifier: ^0.11.3
+        version: 0.11.3
       pagefind:
         specifier: ^1.3.0
         version: 1.3.0
@@ -2280,6 +2283,10 @@ packages:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanostores@0.11.3:
+    resolution: {integrity: sha512-TUes3xKIX33re4QzdxwZ6tdbodjmn3tWXCEc1uokiEmo14sI1EaGYNs2k3bU2pyyGNmBqFGAVl6jAGWd06AVIg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -6085,6 +6092,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.8: {}
+
+  nanostores@0.11.3: {}
 
   neotraverse@0.6.18: {}
 

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -13,7 +13,14 @@ import "@fontsource/b612-mono/700.css";
 import "@/styles/markdownAlert.css";
 import "katex/dist/katex.min.css";
 
-const { created, updated, description, ogImage, title, types } = pageMetadata.get();
+const {
+  created,
+  updated,
+  description,
+  ogImage = "/social-card.png",
+  title,
+  types = [],
+} = pageMetadata.get();
 
 const isPost = ["post", "draft"].some((t) => types.includes(t));
 const isTag = types.includes("tag");
@@ -21,13 +28,15 @@ const isTag = types.includes("tag");
 const titleSeparator = "•";
 const siteTitle = `${title} ${titleSeparator} ${siteConfig.title}`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url).href;
+const socialImageURL = new URL(ogImage, Astro.url).href;
+
+let createdTime, updatedTime, blogJsonLd;
 
 if (isPost) {
-  const createdTime = created.toISOString();
-  const updatedTime = updated.toISOString();
+  createdTime = created.toISOString();
+  updatedTime = updated.toISOString();
 
-  const blogJsonLd = createdTime && {
+  blogJsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     mainEntityOfPage: {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -15,32 +15,37 @@ import "katex/dist/katex.min.css";
 
 const { created, updated, description, ogImage, title, types } = pageMetadata.get();
 
+const isPost = ["post", "draft"].some((t) => types.includes(t));
+const isTag = types.includes("tag");
+
 const titleSeparator = "•";
 const siteTitle = `${title} ${titleSeparator} ${siteConfig.title}`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url).href;
-const isTagPage = /\/blog\/tags/.test(Astro.url.pathname);
-const createdTime = created?.toISOString();
-const updatedTime = updated?.toISOString();
 
-const blogJsonLd = createdTime && {
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  mainEntityOfPage: {
-    "@type": "WebPage",
-    "@id": canonicalURL,
-  },
-  headline: title,
-  description: description,
-  image: socialImageURL,
-  author: {
-    "@type": "Person",
-    name: siteConfig.author,
-    url: Astro.site,
-  },
-  datePublished: createdTime,
-  dateModified: updatedTime,
-};
+if (isPost) {
+  const createdTime = created.toISOString();
+  const updatedTime = updated.toISOString();
+
+  const blogJsonLd = createdTime && {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": canonicalURL,
+    },
+    headline: title,
+    description: description,
+    image: socialImageURL,
+    author: {
+      "@type": "Person",
+      name: siteConfig.author,
+      url: Astro.site,
+    },
+    datePublished: createdTime,
+    dateModified: updatedTime,
+  };
+}
 ---
 
 <meta charset="utf-8" />
@@ -64,7 +69,7 @@ const blogJsonLd = createdTime && {
 <meta content="" name="theme-color" />
 
 {/* Open Graph / Facebook */}
-<meta content={createdTime ? "article" : "website"} property="og:type" />
+<meta content={isPost ? "article" : "website"} property="og:type" />
 <meta content={title} property="og:title" />
 <meta content={description} property="og:description" />
 <meta content={canonicalURL} property="og:url" />
@@ -74,14 +79,16 @@ const blogJsonLd = createdTime && {
 <meta content="1200" property="og:image:width" />
 <meta content="630" property="og:image:height" />
 {
-  createdTime && (
+  isPost && (
     <>
       <meta content={siteConfig.author} property="article:author" />
       <meta content={createdTime} property="article:published_time" />
+      <meta content={updatedTime} property="article:modified_time" />
+      {/* JSON-LD */}
+      <script type="application/ld+json" set:html={JSON.stringify(blogJsonLd)} />
     </>
   )
 }
-{updatedTime && <meta content={updatedTime} property="article:modified_time" />}
 
 {/* Twitter */}
 <meta content="summary_large_image" property="twitter:card" />
@@ -90,9 +97,6 @@ const blogJsonLd = createdTime && {
 <meta content={description} property="twitter:description" />
 <meta content={socialImageURL} property="twitter:image" />
 
-{/* JSON-LD */}
-{createdTime && <script type="application/ld+json" set:html={JSON.stringify(blogJsonLd)} />}
-
 {/* Sitemap */}
 <link href="/sitemap-index.xml" rel="sitemap" />
 
@@ -100,11 +104,11 @@ const blogJsonLd = createdTime && {
 <link href="/rss.xml" rel="alternate" title={siteConfig.title} type="application/rss+xml" />
 
 {/* No Index for tag pages */}
-{isTagPage && <meta content="noindex" name="robots" />}
+{isTag && <meta content="noindex" name="robots" />}
 
 {/* Adsense */}
 {
-  !isTagPage && (
+  !isTag && (
     <script
       async
       src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2628442340171104"

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,6 @@
 ---
 import { siteConfig } from "@/site.config";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 import "@/styles/global.css";
 
@@ -12,7 +13,7 @@ import "@fontsource/b612-mono/700.css";
 import "@/styles/markdownAlert.css";
 import "katex/dist/katex.min.css";
 
-const { createdTime, updatedTime, description, ogImage, title } = Astro.props;
+const { createdTime, updatedTime, description, ogImage, title } = pageMetadata.get();
 
 const titleSeparator = "•";
 const siteTitle = `${title} ${titleSeparator} ${siteConfig.title}`;

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -13,13 +13,15 @@ import "@fontsource/b612-mono/700.css";
 import "@/styles/markdownAlert.css";
 import "katex/dist/katex.min.css";
 
-const { createdTime, updatedTime, description, ogImage, title } = pageMetadata.get();
+const { created, updated, description, ogImage, title } = pageMetadata.get();
 
 const titleSeparator = "•";
 const siteTitle = `${title} ${titleSeparator} ${siteConfig.title}`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const socialImageURL = new URL(ogImage ? ogImage : "/social-card.png", Astro.url).href;
 const isTagPage = /\/blog\/tags/.test(Astro.url.pathname);
+const createdTime = created?.toISOString();
+const updatedTime = updated?.toISOString();
 
 const blogJsonLd = createdTime && {
   "@context": "https://schema.org",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -13,7 +13,7 @@ import "@fontsource/b612-mono/700.css";
 import "@/styles/markdownAlert.css";
 import "katex/dist/katex.min.css";
 
-const { created, updated, description, ogImage, title } = pageMetadata.get();
+const { created, updated, description, ogImage, title, types } = pageMetadata.get();
 
 const titleSeparator = "•";
 const siteTitle = `${title} ${titleSeparator} ${siteConfig.title}`;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -5,21 +5,11 @@ import ThemeProvider from "@/components/ThemeProvider.astro";
 import Footer from "@/components/layout/Footer.astro";
 import Header from "@/components/layout/Header.astro";
 import { siteConfig } from "@/site.config";
-
-const {
-  meta: { createdTime, updatedTime, description = siteConfig.description, ogImage, title },
-} = Astro.props;
 ---
 
 <html class="scroll-smooth" lang={siteConfig.lang}>
   <head>
-    <BaseHead
-      createdTime={createdTime}
-      updatedTime={updatedTime}
-      description={description}
-      ogImage={ogImage}
-      title={title}
-    />
+    <BaseHead />
   </head>
   <body
     class="mx-auto flex min-h-screen max-w-3xl flex-col bg-bgColor px-4 pt-16 text-base font-normal text-textColor antialiased sm:px-8"

--- a/src/layouts/BaseContent.astro
+++ b/src/layouts/BaseContent.astro
@@ -1,10 +1,8 @@
 ---
 import BaseLayout from "./Base.astro";
-
-const { meta } = Astro.props;
 ---
 
-<BaseLayout meta={meta}>
+<BaseLayout>
   <div class="gap-x-10 lg:flex lg:items-start">
     <slot name="toc" />
     <article class="flex-grow break-words" data-pagefind-body>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,13 +5,12 @@ import TOC from "@/components/blog/TOC.astro";
 
 import BaseContentLayout from "./BaseContent.astro";
 
-const { post } = Astro.props;
-const { headings, remarkPluginFrontmatter } = await render(post);
+const { post, headings, readingTime } = Astro.props;
 ---
 
 <BaseContentLayout>
   {!!headings.length && <TOC headings={headings} slot="toc" />}
-  <BlogHero content={post} readingTime={remarkPluginFrontmatter.readingTime} slot="hero" />
+  <BlogHero content={post} readingTime={readingTime} slot="hero" />
   <div
     class="prose prose-cactus mt-12 text-base prose-headings:font-semibold prose-headings:text-accent-2 prose-headings:before:absolute prose-headings:before:-ms-5 prose-headings:before:text-accent sm:prose-headings:before:content-['#'] sm:prose-th:before:content-none"
   >

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,13 +6,6 @@ import TOC from "@/components/blog/TOC.astro";
 import BaseContentLayout from "./BaseContent.astro";
 
 const { post } = Astro.props;
-const {
-  data: { created, title, updated },
-  id,
-} = post;
-const createdTime = created.toISOString();
-const updatedTime = updated.toISOString();
-const socialImage = `/og-image/${id}.png`;
 const { headings, remarkPluginFrontmatter } = await render(post);
 ---
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -16,15 +16,7 @@ const socialImage = `/og-image/${id}.png`;
 const { headings, remarkPluginFrontmatter } = await render(post);
 ---
 
-<BaseContentLayout
-  meta={{
-    createdTime,
-    updatedTime,
-    description: remarkPluginFrontmatter.excerpt,
-    ogImage: socialImage,
-    title,
-  }}
->
+<BaseContentLayout>
   {!!headings.length && <TOC headings={headings} slot="toc" />}
   <BlogHero content={post} readingTime={remarkPluginFrontmatter.readingTime} slot="hero" />
   <div

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -1,8 +1,14 @@
 ---
+import { pageMetadata } from "@/stores/pageMetadata";
 import BaseContentLayout from "./BaseContent.astro";
 
 const { frontmatter } = Astro.props;
 const { title, description } = frontmatter;
+
+pageMetadata.set({
+  description,
+  title,
+});
 ---
 
 <BaseContentLayout

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -11,12 +11,7 @@ pageMetadata.set({
 });
 ---
 
-<BaseContentLayout
-  meta={{
-    description,
-    title,
-  }}
->
+<BaseContentLayout>
   <h1 class="title mb-6" slot="hero">{title}</h1>
   <div
     class="prose prose-cactus text-base prose-headings:font-semibold prose-headings:text-accent-2 prose-th:before:content-none"

--- a/src/layouts/page/BlogList.astro
+++ b/src/layouts/page/BlogList.astro
@@ -6,11 +6,6 @@ import PageLayout from "@/layouts/Base.astro";
 
 const { page, uniqueTags } = Astro.props;
 
-const meta = {
-  description: "部落格文章列表",
-  title: "Posts",
-};
-
 const paginationProps = {
   ...(page.url.prev && {
     prevUrl: {
@@ -30,7 +25,7 @@ const groupedByYear = groupPostsByYear(page.data);
 const descYearKeys = Object.keys(groupedByYear).sort((a, b) => +b - +a);
 ---
 
-<PageLayout meta={meta}>
+<PageLayout>
   <h1 class="title mb-6 flex items-center gap-3">Posts</h1>
   <div class="grid gap-y-16 sm:grid-cols-[3fr_1fr] sm:gap-x-8">
     <section aria-label="Blog post list">

--- a/src/layouts/page/TagPostList.astro
+++ b/src/layouts/page/TagPostList.astro
@@ -5,11 +5,6 @@ import PageLayout from "@/layouts/Base.astro";
 
 const { page, tag } = Astro.props;
 
-const meta = {
-  description: `檢視所有含有 ${tag} 標籤的文章`,
-  title: `Tag: ${tag}`,
-};
-
 const paginationProps = {
   ...(page.url.prev && {
     prevUrl: {
@@ -26,7 +21,7 @@ const paginationProps = {
 };
 ---
 
-<PageLayout meta={meta}>
+<PageLayout>
   <h1 class="title mb-6 flex items-center">
     <a class="text-accent sm:hover:underline" href="/blog/tags/">Tags</a>
     <span class="me-3 ms-2">→</span>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,10 +1,16 @@
 ---
+import { pageMetadata } from "@/stores/pageMetadata";
 import PageLayout from "@/layouts/Base.astro";
 
 const meta = {
   description: "哎呀！看來這個頁面已經消失在太空中了！",
   title: "哎呀！你發現了消失的頁面！",
 };
+
+pageMetadata.set({
+  description: "哎呀！看來這個頁面已經消失在太空中了！",
+  title: "哎呀！你發現了消失的頁面！",
+});
 ---
 
 <PageLayout meta={meta}>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,18 +2,13 @@
 import { pageMetadata } from "@/stores/pageMetadata";
 import PageLayout from "@/layouts/Base.astro";
 
-const meta = {
-  description: "哎呀！看來這個頁面已經消失在太空中了！",
-  title: "哎呀！你發現了消失的頁面！",
-};
-
 pageMetadata.set({
   description: "哎呀！看來這個頁面已經消失在太空中了！",
   title: "哎呀！你發現了消失的頁面！",
 });
 ---
 
-<PageLayout meta={meta}>
+<PageLayout>
   <h1 class="title mb-6">404 | 找不到網頁</h1>
   <p class="mb-8">請使用導覽列回去</p>
 </PageLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -29,6 +29,7 @@ pageMetadata.set({
   title,
   description: excerpt,
   ogImage: `/og-image/${id}.png`,
+  type: ["post"],
 });
 ---
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,6 +2,7 @@
 import { render } from "astro:content";
 import PostLayout from "@/layouts/BlogPost.astro";
 import { getAllPosts } from "@/data/post";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 export const getStaticPaths = async () => {
   const blogEntries = await getAllPosts();
@@ -12,7 +13,22 @@ export const getStaticPaths = async () => {
 };
 
 const { entry } = Astro.props;
-const { Content } = await render(entry);
+const {
+  Content,
+  remarkPluginFrontmatter: { excerpt },
+} = await render(entry);
+const {
+  data: { created, title, updated },
+  id,
+} = entry;
+
+pageMetadata.set({
+  created,
+  updated,
+  title,
+  description: excerpt,
+  ogImage: `/og-image/${id}.png`,
+});
 ---
 
 <PostLayout post={entry}>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -15,7 +15,8 @@ export const getStaticPaths = async () => {
 const { entry } = Astro.props;
 const {
   Content,
-  remarkPluginFrontmatter: { excerpt },
+  headings,
+  remarkPluginFrontmatter: { excerpt, readingTime },
 } = await render(entry);
 const {
   data: { created, title, updated },
@@ -31,6 +32,6 @@ pageMetadata.set({
 });
 ---
 
-<PostLayout post={entry}>
+<PostLayout post={entry} headings={headings} readingTime={readingTime}>
   <Content />
 </PostLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -29,7 +29,7 @@ pageMetadata.set({
   title,
   description: excerpt,
   ogImage: `/og-image/${id}.png`,
-  type: ["post"],
+  types: ["post"],
 });
 ---
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -3,6 +3,7 @@ import { getAllPosts, getTopTags } from "@/data/post";
 import BlogList from "@/layouts/page/BlogList.astro";
 import { collectionDateSort } from "@/utils/date";
 import { siteConfig } from "@/site.config";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 const MAX_TAGS = 7;
 const allPosts = await getAllPosts();
@@ -19,6 +20,11 @@ const page = {
   },
   data: firstPagePostsByDate,
 };
+
+pageMetadata.set({
+  description: "部落格文章列表",
+  title: "Posts",
+});
 ---
 
 <BlogList page={page} uniqueTags={uniqueTags} />

--- a/src/pages/blog/page/[...page].astro
+++ b/src/pages/blog/page/[...page].astro
@@ -3,6 +3,7 @@ import { getAllPosts, getTopTags } from "@/data/post";
 import BlogList from "@/layouts/page/BlogList.astro";
 import { collectionDateSort } from "@/utils/date";
 import { siteConfig } from "@/site.config";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 export const getStaticPaths = async ({ paginate }) => {
   const MAX_TAGS = 7;
@@ -15,6 +16,11 @@ export const getStaticPaths = async ({ paginate }) => {
 };
 
 const { page, uniqueTags } = Astro.props;
+
+pageMetadata.set({
+  description: "部落格文章列表",
+  title: "Posts",
+});
 ---
 
 <BlogList page={page} uniqueTags={uniqueTags} />

--- a/src/pages/blog/tags/[tag]/index.astro
+++ b/src/pages/blog/tags/[tag]/index.astro
@@ -38,7 +38,7 @@ const { tag } = Astro.params;
 pageMetadata.set({
   description: `檢視所有含有 ${tag} 標籤的文章`,
   title: `Tag: ${tag}`,
-  type: ["tag"],
+  types: ["tag"],
 });
 ---
 

--- a/src/pages/blog/tags/[tag]/index.astro
+++ b/src/pages/blog/tags/[tag]/index.astro
@@ -38,6 +38,7 @@ const { tag } = Astro.params;
 pageMetadata.set({
   description: `檢視所有含有 ${tag} 標籤的文章`,
   title: `Tag: ${tag}`,
+  type: ["tag"],
 });
 ---
 

--- a/src/pages/blog/tags/[tag]/index.astro
+++ b/src/pages/blog/tags/[tag]/index.astro
@@ -3,6 +3,7 @@ import { getAllPosts, getUniqueTags } from "@/data/post";
 import TagPostList from "@/layouts/page/TagPostList.astro";
 import { collectionDateSort } from "@/utils/date";
 import { siteConfig } from "@/site.config";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 export const getStaticPaths = async ({ paginate }) => {
   const allPosts = await getAllPosts();
@@ -33,6 +34,11 @@ export const getStaticPaths = async ({ paginate }) => {
 
 const { page } = Astro.props;
 const { tag } = Astro.params;
+
+pageMetadata.set({
+  description: `檢視所有含有 ${tag} 標籤的文章`,
+  title: `Tag: ${tag}`,
+});
 ---
 
 <TagPostList page={page} tag={tag} />

--- a/src/pages/blog/tags/[tag]/page/[...page].astro
+++ b/src/pages/blog/tags/[tag]/page/[...page].astro
@@ -3,6 +3,7 @@ import { getAllPosts, getUniqueTags } from "@/data/post";
 import TagPostList from "@/layouts/page/TagPostList.astro";
 import { collectionDateSort } from "@/utils/date";
 import { siteConfig } from "@/site.config";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 export const getStaticPaths = async ({ paginate }) => {
   const allPosts = await getAllPosts();
@@ -20,6 +21,11 @@ export const getStaticPaths = async ({ paginate }) => {
 
 const { page } = Astro.props;
 const { tag } = Astro.params;
+
+pageMetadata.set({
+  description: `檢視所有含有 ${tag} 標籤的文章`,
+  title: `Tag: ${tag}`,
+});
 ---
 
 <TagPostList page={page} tag={tag} />

--- a/src/pages/blog/tags/[tag]/page/[...page].astro
+++ b/src/pages/blog/tags/[tag]/page/[...page].astro
@@ -25,7 +25,7 @@ const { tag } = Astro.params;
 pageMetadata.set({
   description: `檢視所有含有 ${tag} 標籤的文章`,
   title: `Tag: ${tag}`,
-  type: ["tag"],
+  types: ["tag"],
 });
 ---
 

--- a/src/pages/blog/tags/[tag]/page/[...page].astro
+++ b/src/pages/blog/tags/[tag]/page/[...page].astro
@@ -25,6 +25,7 @@ const { tag } = Astro.params;
 pageMetadata.set({
   description: `檢視所有含有 ${tag} 標籤的文章`,
   title: `Tag: ${tag}`,
+  type: ["tag"],
 });
 ---
 

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -9,7 +9,7 @@ const allTags = getUniqueTagsWithCount(allPosts);
 pageMetadata.set({
   description: "文章中出現過的標籤列表",
   title: "All Tags",
-  type: ["tag"],
+  types: ["tag"],
 });
 ---
 

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,14 +1,20 @@
 ---
 import PageLayout from "@/layouts/Base.astro";
 import { getAllPosts, getUniqueTagsWithCount } from "@/data/post";
+import { pageMetadata } from "@/stores/pageMetadata";
 
 const allPosts = await getAllPosts();
 const allTags = getUniqueTagsWithCount(allPosts);
 
 const meta = {
-  description: "我在文章中出現過的標籤列表",
+  description: "文章中出現過的標籤列表",
   title: "All Tags",
 };
+
+pageMetadata.set({
+  description: "文章中出現過的標籤列表",
+  title: "All Tags",
+});
 ---
 
 <PageLayout meta={meta}>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -6,18 +6,13 @@ import { pageMetadata } from "@/stores/pageMetadata";
 const allPosts = await getAllPosts();
 const allTags = getUniqueTagsWithCount(allPosts);
 
-const meta = {
-  description: "文章中出現過的標籤列表",
-  title: "All Tags",
-};
-
 pageMetadata.set({
   description: "文章中出現過的標籤列表",
   title: "All Tags",
 });
 ---
 
-<PageLayout meta={meta}>
+<PageLayout>
   <h1 class="title mb-6">Tags</h1>
   <ul class="space-y-4">
     {

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -9,6 +9,7 @@ const allTags = getUniqueTagsWithCount(allPosts);
 pageMetadata.set({
   description: "文章中出現過的標籤列表",
   title: "All Tags",
+  type: ["tag"],
 });
 ---
 

--- a/src/pages/drafts/[...showDraftsPage].astro
+++ b/src/pages/drafts/[...showDraftsPage].astro
@@ -18,18 +18,13 @@ export const getStaticPaths = () => {
 
 const drafts = (await getAllDrafts()).sort(collectionDateSort);
 
-const meta = {
-  description: "部落格草稿列表",
-  title: "Drafts",
-};
-
 pageMetadata.set({
   description: "部落格草稿列表",
   title: "Drafts",
 });
 ---
 
-<PageLayout meta={meta}>
+<PageLayout>
   <h1 class="title mb-6 flex items-center gap-3">Drafts</h1>
   <div class="grid gap-y-16 sm:grid-cols-[3fr_1fr] sm:gap-x-8">
     <section aria-label="Blog post list">

--- a/src/pages/drafts/[...showDraftsPage].astro
+++ b/src/pages/drafts/[...showDraftsPage].astro
@@ -1,6 +1,7 @@
 ---
 import { getAllDrafts } from "@/data/post";
 import { collectionDateSort } from "@/utils/date";
+import { pageMetadata } from "@/stores/pageMetadata";
 import PageLayout from "@/layouts/Base.astro";
 
 export const getStaticPaths = () => {
@@ -21,6 +22,11 @@ const meta = {
   description: "部落格草稿列表",
   title: "Drafts",
 };
+
+pageMetadata.set({
+  description: "部落格草稿列表",
+  title: "Drafts",
+});
 ---
 
 <PageLayout meta={meta}>

--- a/src/pages/drafts/[...slug].astro
+++ b/src/pages/drafts/[...slug].astro
@@ -19,7 +19,8 @@ export const getStaticPaths = async () => {
 const { entry } = Astro.props;
 const {
   Content,
-  remarkPluginFrontmatter: { excerpt },
+  headings,
+  remarkPluginFrontmatter: { excerpt, readingTime },
 } = await render(entry);
 const {
   data: { created, title, updated },
@@ -34,6 +35,6 @@ pageMetadata.set({
 });
 ---
 
-<PostLayout post={entry}>
+<PostLayout post={entry} headings={headings} readingTime={readingTime}>
   <Content />
 </PostLayout>

--- a/src/pages/drafts/[...slug].astro
+++ b/src/pages/drafts/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { render } from "astro:content";
 import { getAllDrafts } from "@/data/post";
+import { pageMetadata } from "@/stores/pageMetadata";
 import PostLayout from "@/layouts/BlogPost.astro";
 
 export const getStaticPaths = async () => {
@@ -16,7 +17,21 @@ export const getStaticPaths = async () => {
 };
 
 const { entry } = Astro.props;
-const { Content } = await render(entry);
+const {
+  Content,
+  remarkPluginFrontmatter: { excerpt },
+} = await render(entry);
+const {
+  data: { created, title, updated },
+  id,
+} = entry;
+
+pageMetadata.set({
+  created,
+  updated,
+  title,
+  description: excerpt,
+});
 ---
 
 <PostLayout post={entry}>

--- a/src/pages/drafts/[...slug].astro
+++ b/src/pages/drafts/[...slug].astro
@@ -32,7 +32,7 @@ pageMetadata.set({
   updated,
   title,
   description: excerpt,
-  type: ["draft"],
+  types: ["draft"],
 });
 ---
 

--- a/src/pages/drafts/[...slug].astro
+++ b/src/pages/drafts/[...slug].astro
@@ -32,6 +32,7 @@ pageMetadata.set({
   updated,
   title,
   description: excerpt,
+  type: ["draft"],
 });
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ pageMetadata.set({
 });
 ---
 
-<PageLayout meta={{ title: "Home" }}>
+<PageLayout>
   <section aria-label="Blog post list" class="mt-16">
     <h2 class="title mb-6 text-xl text-accent">最新文章</h2>
     <ul class="space-y-4">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,10 +3,17 @@ import PostPreview from "@/components/blog/PostPreview.astro";
 import { getAllPosts } from "@/data/post";
 import PageLayout from "@/layouts/Base.astro";
 import { collectionDateSort } from "@/utils/date";
+import { pageMetadata } from "@/stores/pageMetadata";
+import { siteConfig } from "@/site.config";
 
 const MAX_POSTS = 10;
 const allPosts = await getAllPosts();
 const allPostsByDate = allPosts.sort(collectionDateSort).slice(0, MAX_POSTS);
+
+pageMetadata.set({
+  description: siteConfig.description,
+  title: "Home",
+});
 ---
 
 <PageLayout meta={{ title: "Home" }}>

--- a/src/stores/pageMetadata.js
+++ b/src/stores/pageMetadata.js
@@ -1,0 +1,4 @@
+import { atom } from "nanostores";
+import { siteConfig } from "@/site.config";
+
+export const pageMetadata = atom({description: siteConfig.description});

--- a/src/stores/pageMetadata.js
+++ b/src/stores/pageMetadata.js
@@ -1,4 +1,7 @@
 import { atom } from "nanostores";
 import { siteConfig } from "@/site.config";
 
-export const pageMetadata = atom({description: siteConfig.description});
+export const pageMetadata = atom({
+  description: siteConfig.description,
+  ogImage: "/social-card.png",
+});

--- a/src/stores/pageMetadata.js
+++ b/src/stores/pageMetadata.js
@@ -1,7 +1,3 @@
 import { atom } from "nanostores";
-import { siteConfig } from "@/site.config";
 
-export const pageMetadata = atom({
-  description: siteConfig.description,
-  ogImage: "/social-card.png",
-});
+export const pageMetadata = atom({});


### PR DESCRIPTION
- [x] set `pageMetadata` for each page
  - blog
    - page
      - [x] [...page].astro 
    - tags
      - [tag]
        - [page]
          - [x] [...page].astro 
        - [x] index.astro
      - [x] index.astro
    - [x] index.astro
    - [x] [...slug].astro 
  - og-image
  - drafts
    - [x] [...showDraftsPage].astro
    - [x] [...slug].astro 
  - [x] about.md
  - [x] 404.astro
  - [x] index.astro
- [x] remove old `meta` parameter
- [ ] apply `pageMetadata` to somewhere else which is suitable